### PR TITLE
fix highlight z-index and box-sizing

### DIFF
--- a/src/lib/components/highlight/Highlight.less
+++ b/src/lib/components/highlight/Highlight.less
@@ -1,10 +1,10 @@
 :local {
   .wrapper {
     position: absolute;
-    z-index: 899;
     top: 0;
     left: 0;
     border-style: solid;
     border-color: transparent;
+    box-sizing: content-box;
   }
 }

--- a/src/lib/components/highlight/Highlight.tsx
+++ b/src/lib/components/highlight/Highlight.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import ZIndex from "@skbkontur/react-ui/components/ZIndex/ZIndex";
 
 const styles = require('./Highlight.less');
 
@@ -36,8 +37,8 @@ export function Highlight(props: HighlightProps) {
   };
 
   return (
-    <div className={styles.wrapper} style={computedStyles}>
+    <ZIndex delta={100} className={styles.wrapper} style={computedStyles}>
       {highlightRoot}
-    </div>
+    </ZIndex>
   );
 }

--- a/src/lib/components/points/Points.less
+++ b/src/lib/components/points/Points.less
@@ -5,12 +5,14 @@
     display: inline-block;
     padding-right: 4px;
     width: 8px;
+    box-sizing: content-box;
   }
 
   .tooltipPointActive {
     position: relative;
     top: 1px;
     width: 10px !important;
+    box-sizing: content-box;
   }
 
   .tooltipPoint:before {

--- a/src/lib/components/tooltip/TooltipHighlight.tsx
+++ b/src/lib/components/tooltip/TooltipHighlight.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import LayoutEvents from '@skbkontur/react-ui/lib/LayoutEvents';
 import RenderContainer from '@skbkontur/react-ui/components/RenderContainer';
+import ZIndex from "@skbkontur/react-ui/components/ZIndex/ZIndex";
 
 import { Highlight } from '../highlight/Highlight';
 
@@ -27,7 +28,9 @@ export class TooltipHighlight extends React.Component<HighlightProps> {
       <div>
         {this.props.children}
         <RenderContainer>
-          <Highlight pos={this.state.pos} highlight={this.props.highlight} />
+          <ZIndex delta={100} style={{position: 'relative'}}>
+            <Highlight pos={this.state.pos} highlight={this.props.highlight} />
+          </ZIndex>
         </RenderContainer>
       </div>
     );

--- a/src/lib/components/tooltip/TooltipHighlight.tsx
+++ b/src/lib/components/tooltip/TooltipHighlight.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import LayoutEvents from '@skbkontur/react-ui/lib/LayoutEvents';
 import RenderContainer from '@skbkontur/react-ui/components/RenderContainer';
-import ZIndex from "@skbkontur/react-ui/components/ZIndex/ZIndex";
 
 import { Highlight } from '../highlight/Highlight';
 
@@ -28,9 +27,7 @@ export class TooltipHighlight extends React.Component<HighlightProps> {
       <div>
         {this.props.children}
         <RenderContainer>
-          <ZIndex delta={100} style={{position: 'relative'}}>
-            <Highlight pos={this.state.pos} highlight={this.props.highlight} />
-          </ZIndex>
+          <Highlight pos={this.state.pos} highlight={this.props.highlight} />
         </RenderContainer>
       </div>
     );


### PR DESCRIPTION
1. Wrap highlight with ZIndex component
2. Set `box-sizing: content-box` explicitly to highlight and tooltip point