### PR TITLE
Fix jest error, add padding prop to Tooltip.Container

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "moduleNameMapper": {
       "\\.(css|less)$": "identity-obj-proxy",
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.ts"
-    }
+    },
+    "testURL": "http://localhost/"
   }
 }

--- a/src/lib/components/tooltip/Tooltip.tsx
+++ b/src/lib/components/tooltip/Tooltip.tsx
@@ -62,12 +62,17 @@ export class Tooltip extends React.Component<TooltipProps> {
   }
 }
 
+export interface TooltipContainerProps {
+  children?: React.ReactNode;
+  padding?: string;
+}
+
 export interface TooltipPartProps {
   children?: React.ReactNode;
 }
 
-export function Container({ children }: TooltipPartProps) {
-  return <div className={styles.container}>{children}</div>;
+export function Container({ children, padding }: TooltipContainerProps) {
+  return <div className={styles.container} style={{ padding }}>{children}</div>;
 }
 
 export function Header({ children }: TooltipPartProps) {

--- a/src/lib/tooltipStep/TooltipStep.tsx
+++ b/src/lib/tooltipStep/TooltipStep.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { TooltipHighlight } from '../components/tooltip/TooltipHighlight';
 import { MultiStepFooter } from '../components/MultiStepFooter';
 import { StepProps, StepInternalProps } from '../tour/Tour';
-import { Tooltip, PinOptions } from '../components/tooltip/Tooltip';
+import {Tooltip, PinOptions, TooltipContainerProps} from '../components/tooltip/Tooltip';
 
 export interface TooltipStepOuterProps {
   target: () => Element;
@@ -22,6 +22,7 @@ export interface TooltipStepOuterProps {
 export interface TooltipStepProps
   extends TooltipStepOuterProps,
     StepProps,
+    TooltipContainerProps,
     Partial<StepInternalProps> {}
 
 export class TooltipStep extends React.Component<TooltipStepProps> {
@@ -52,7 +53,7 @@ export class TooltipStep extends React.Component<TooltipStepProps> {
         onClose={this.props.onClose}
         width={this.props.width}
       >
-        <Tooltip.Container>
+        <Tooltip.Container padding={this.props.padding}>
           <Tooltip.Header>{this.props.header}</Tooltip.Header>
           <Tooltip.Body>{this.props.content}</Tooltip.Body>
           <Tooltip.Footer>{this.renderTooltipFooter()}</Tooltip.Footer>


### PR DESCRIPTION
Добавил проп `padding` в `Tooltip.Container`, потому как хотелось настраивать отступы в тултипе без хаков с отрицательными маргинами.

Также пофиксил выстрелившую проблему с Jest'ом - https://stackoverflow.com/questions/51554366/jest-securityerror-localstorage-is-not-available-for-opaque-origins