### PR TITLE
Fix highlight infinite scroll

### DIFF
--- a/src/lib/components/highlight/Highlight.tsx
+++ b/src/lib/components/highlight/Highlight.tsx
@@ -26,12 +26,14 @@ export function Highlight(props: HighlightProps) {
 
   const width = pos.right - pos.left;
   const height = pos.bottom - pos.top;
+  const borderTopWidth = pos.top + document.documentElement.scrollTop;
+  const borderLeftWidth = pos.left + document.documentElement.scrollLeft;
   const computedStyles: React.CSSProperties = {
     borderColor: color,
-    borderTopWidth: pos.top + document.documentElement.scrollTop,
-    borderLeftWidth: pos.left + document.documentElement.scrollLeft,
-    borderRightWidth: document.documentElement.offsetWidth - (pos.left + document.documentElement.scrollLeft) - width,
-    borderBottomWidth: document.documentElement.offsetHeight - (pos.top + document.documentElement.scrollTop) - height,
+    borderTopWidth,
+    borderLeftWidth,
+    borderRightWidth: document.documentElement.offsetWidth - (borderLeftWidth + width),
+    borderBottomWidth: document.documentElement.offsetHeight - (borderTopWidth + height),
     width: width,
     height: height
   };

--- a/src/lib/components/highlight/Highlight.tsx
+++ b/src/lib/components/highlight/Highlight.tsx
@@ -30,8 +30,8 @@ export function Highlight(props: HighlightProps) {
     borderColor: color,
     borderTopWidth: pos.top + document.documentElement.scrollTop,
     borderLeftWidth: pos.left + document.documentElement.scrollLeft,
-    borderRightWidth: document.documentElement.offsetWidth - pos.right,
-    borderBottomWidth: document.documentElement.offsetHeight - pos.bottom,
+    borderRightWidth: document.documentElement.offsetWidth - (pos.left + document.documentElement.scrollLeft) - width,
+    borderBottomWidth: document.documentElement.offsetHeight - (pos.top + document.documentElement.scrollTop) - height,
     width: width,
     height: height
   };


### PR DESCRIPTION
Пофиксил мелкий баг с бесконечным скроллом в случае, если показан Highlight.

Баг можно воспроизвести в демо на http://tech.skbkontur.ru/react-ui-tour/
1. Прощелкать тур до второго шага, чтобы был показан оранжевый хайлайт
2. Открыть DevTools
3. Добавить width: 110% и height: 110% на body и html
4. Убрать overflow: hidden из стилей body
5. Попробовать поскроллить горизонтально или вертикально