### PR TITLE
Export TooltipHighlight, fix jest error

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "moduleNameMapper": {
       "\\.(css|less)$": "identity-obj-proxy",
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.ts"
-    }
+    },
+    "testURL": "http://localhost/"
   }
 }

--- a/src/lib/components/tooltip/TooltipHighlight.tsx
+++ b/src/lib/components/tooltip/TooltipHighlight.tsx
@@ -11,13 +11,13 @@ const initialRect = {
   bottom: 0
 } as ClientRect;
 
-export interface HighlightProps {
+export interface TooltipHighlightProps {
   targetGetter: () => Element;
   highlight: React.ReactElement<any>;
   children: React.ReactElement<any>;
 }
 
-export class TooltipHighlight extends React.Component<HighlightProps> {
+export class TooltipHighlight extends React.Component<TooltipHighlightProps> {
   state = { pos: initialRect };
   _layoutEventsToken;
   target;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,6 +3,7 @@ export * from './tour/Tour';
 export * from './step/step';
 export * from './tooltipStep/TooltipStep';
 export * from './components/tooltip/Tooltip';
+export * from './components/tooltip/TooltipHighlight';
 export * from './components/footer/Footer';
 export * from './modalStep/ModalStep';
 export * from './components/highlight/Highlight';


### PR DESCRIPTION
Заэкспортировал TooltipHighlight, переименовал его пропсы в TooltipHighlightProps из-за конфликта с пропсами Highlight.

Оставил фикс Jest'а - https://stackoverflow.com/questions/51554366/jest-securityerror-localstorage-is-not-available-for-opaque-origins