### PR TITLE
Enabling Minitooltip to track multiple elements

### DIFF
--- a/src/lib/components/miniTooltip/MiniTooltip.tsx
+++ b/src/lib/components/miniTooltip/MiniTooltip.tsx
@@ -100,7 +100,7 @@ export class MiniTooltip extends React.Component<MiniTooltipProps> {
         return (
             <ThemeProvider value={MiniTooltipTheme}>
                 <RenderLayer
-                    onClickOutside={e => isClickOnTarget(e) && this.props.onClose()}
+                    onClickOutside={e => isClickOnTarget(e) && this.props.onTargetClicked()}
                     active
                 >
                     <Popup

--- a/src/lib/components/miniTooltip/MiniTooltip.tsx
+++ b/src/lib/components/miniTooltip/MiniTooltip.tsx
@@ -52,15 +52,7 @@ const MiniTooltipTheme = ThemeFactory.create({
 });
 
 function arrayOrItemToArray<T>(arrayOrItem: T | T[]): T[] {
-    const asArray = arrayOrItem as T[];
-    if (asArray)
-        return asArray
-
-    const asItem = arrayOrItem as T;
-    if (asItem)
-        return [asItem]
-
-    return []
+    return [].concat(arrayOrItem)
 }
 
 export class MiniTooltip extends React.Component<MiniTooltipProps> {

--- a/src/lib/miniTooltipStep/MiniTooltipStep.tsx
+++ b/src/lib/miniTooltipStep/MiniTooltipStep.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import {StepInternalProps} from "../tour/Tour";
 
 export interface MiniTooltipStepProps extends Partial<StepInternalProps> {
-    target: () => Element;
+    target: (() => Element) | (() => Element)[];
     positions: PopupPosition[];
     children?: any;
     width?: string,

--- a/src/lib/miniTooltipStep/MiniTooltipStep.tsx
+++ b/src/lib/miniTooltipStep/MiniTooltipStep.tsx
@@ -3,7 +3,8 @@ import * as React from "react";
 import {StepInternalProps} from "../tour/Tour";
 
 export interface MiniTooltipStepProps extends Partial<StepInternalProps> {
-    target: (() => Element) | (() => Element)[];
+    target: () => Element;
+    triggers?: (() => Element)[];
     positions: PopupPosition[];
     children?: any;
     width?: string,
@@ -16,12 +17,14 @@ export class MiniTooltipStep extends React.Component<MiniTooltipStepProps> {
             onClose,
             positions,
             target,
+            triggers,
             children,
             width
         } = this.props;
 
         return <MiniTooltip
             target={target}
+            triggers={triggers}
             positions={positions}
             onClose={onClose}
             onTargetClicked={onNext}


### PR DESCRIPTION
Чтобы воспользоваться функцией надо передать в target массив локаторов
Первый элемент используется в качестве цели тултипа.
При клике на один из элементов, список локаторов которых был передан, срабатывает onNext